### PR TITLE
docs: remove integrity check on draw io viewer

### DIFF
--- a/docs/spec/tlm.html
+++ b/docs/spec/tlm.html
@@ -11,7 +11,6 @@
 <script
   type="text/javascript"
   src="https://www.draw.io/js/viewer.min.js"
-  integrity="sha384-XDK6fZ6B+R/1M/tgCfIhrfPsJeEJQfgfljMAQwR0nNdJjL0fYd/CX7awCOvKHViW"
   crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
This was a silly auto fix that breaks the page whenever draw.io updates.