### PR TITLE
docs(agents): PR-workflow session completion + ci-watch task

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -43,6 +43,25 @@ depends = ["ts:clean"]
 description = "Full CI gate (TS + Rust)"
 depends = ["ci:ts", "ci:rust"]
 
+[tasks.ci-watch]
+description = "Watch PR checks (or the latest run) for the current branch; exits non-zero on failure"
+run = """
+set -e
+branch=$(git branch --show-current)
+if [ -z "$branch" ]; then echo "Detached HEAD — no branch to watch" >&2; exit 1; fi
+sleep 3
+pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number' 2>/dev/null || true)
+if [ -n "$pr" ]; then
+  echo "Watching checks on PR #$pr ($branch)..."
+  gh pr checks "$pr" --watch
+else
+  run_id=$(gh run list --branch "$branch" --limit 1 --json databaseId --jq '.[0].databaseId' 2>/dev/null || true)
+  if [ -z "$run_id" ]; then echo "No open PR or recent run found for $branch" >&2; exit 1; fi
+  echo "No open PR for $branch; watching run $run_id..."
+  gh run watch --exit-status "$run_id"
+fi
+"""
+
 # ---------- TypeScript ----------
 [tasks."ts:install"]
 description = "pnpm install"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,33 @@
 # Agent Instructions for tlm
 
-Type Link Model (TLM) - multi-language monorepo with TypeScript and Rust.
+> This file (`AGENTS.md`) is the canonical agent configuration. `CLAUDE.md` is a symlink to this file.
+
+Type Link Model (TLM) — polyglot monorepo with TypeScript + Rust. Each
+language uses its native workspace (pnpm, Cargo). [`mise`](https://mise.jdx.dev/)
+is the top-level entry point: it pins every toolchain version and exposes
+every repo command as a task (see `.mise.toml`). Tasks are namespaced
+`<lang>:<verb>` so you can fan out at any granularity.
 
 ## Quick Reference
 
-- **One-time**: `mise install`
-- **Install deps**: `mise run install`
-- **Lint**: `mise run lint` (or `ts:lint` / `rs:lint` per language)
-- **Format**: `mise run format`
+First time in a fresh clone: `mise install` (downloads + pins the
+toolchain), then `mise run install` (pnpm install).
+
+- **Install all deps**: `mise run install`
+- **Lint all**: `mise run lint` (or `ts:lint` / `rs:lint` per language)
+- **Format all**: `mise run format`
 - **Test (unit)**: `mise run test`
 - **Postgres lifecycle** (for integration/SQL tests): `mise run sql:setup` / `sql:destroy`
-- **CI (TS)**: `mise run ci:ts`
-- **CI (Rust)**: `mise run ci:rust`
+- **CI per language**: `mise run ci:ts` / `mise run ci:rust`
 - **Full CI gate**: `mise run ci`
+- **Watch PR CI**: `mise run ci-watch`
+
+Per-language native commands still work when mise isn't in the way:
+
+| Language   | Install         | Lint                                                                                              | Test                 |
+|------------|-----------------|---------------------------------------------------------------------------------------------------|----------------------|
+| TypeScript | `pnpm install`  | `pnpm lint` (from repo root)                                                                      | `pnpm -r run test`   |
+| Rust       | (none)          | `cargo fmt --all --check && cargo clippy --workspace --all-targets --all-features -- -D warnings` | `cargo test --workspace --all-targets` |
 
 ## Structure
 
@@ -57,17 +72,52 @@ Follow [Conventional Commits](https://conventionalcommits.org/):
 
 ## Session Completion
 
-Work is NOT complete until `git push` succeeds.
+Work is NOT complete until a PR is merged and local `main` is back in
+sync with `origin/main`. Drive every change through a short-lived
+branch; do not commit directly to `main`.
 
 1. **Quality gates** (if code changed):
    ```bash
    mise run ci
    ```
 
-2. **Push**:
+2. **Branch + commit**: if you're still on `main`, cut a feature
+   branch before committing. Use a Conventional-Commits type as the
+   branch prefix (`feat/...`, `fix/...`, `chore/bump-deps`, etc.).
+   Stage files by name — avoid `git add -A` / `git add .` so secrets
+   and build output don't sneak in.
    ```bash
-   git pull --rebase && git push
-   git status  # must show "up to date with origin"
+   git checkout -b <type>/<short-slug>
+   git status
+   git add <files>
+   git commit -m "<type>(<scope>): <description>"
    ```
 
-Never stop before pushing. If push fails, resolve and retry.
+3. **Push the branch**:
+   ```bash
+   git push -u origin HEAD
+   ```
+
+4. **Open a PR** against `main`:
+   ```bash
+   gh pr create --base main \
+     --title "<type>(<scope>): <description>" \
+     --body "<summary + test plan>"
+   ```
+
+5. **Watch CI** until every required check is green:
+   ```bash
+   mise run ci-watch
+   ```
+   On failure, inspect with `gh run view --log-failed`, fix, commit,
+   push, and re-watch. Do not proceed until the PR is green.
+
+6. **Merge + sync**:
+   ```bash
+   gh pr merge --merge --delete-branch
+   git checkout main && git pull
+   git status  # must show "up to date with origin/main"
+   ```
+
+Never stop before `main` is updated with the merged change. If any step
+fails, resolve and retry — don't hand back a half-shipped change.


### PR DESCRIPTION
## Summary

- Adopts the canonical-AGENTS.md / polyglot-monorepo framing and native-command table from `lsimons-template-mono` and tunes them for this repo.
- Rewrites **Session Completion** as a 6-step PR flow (branch → commit → push → `gh pr create` → `mise run ci-watch` → merge + sync). The "work is not complete until…" bar is now "PR merged and local `main` back in sync", not just "`git push` succeeded".
- Adds a `ci-watch` mise task that watches the open PR's checks for the current branch (falling back to the latest Actions run if no PR yet) and exits non-zero on failure, so step 5 is a single command.

No code changes; no runtime impact.

## Test plan

- [x] `mise tasks` lists the new `ci-watch` task
- [x] `mise run ci-watch --help` parses the task definition
- [ ] GitHub Actions CI green on this PR

Assisted-by: Claude:claude-opus-4-7
Co-Authored-By: lsimons-bot <bot@leosimons.com>