### PR TITLE
docs(readme): rewrite as archival tombstone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,87 @@
-# [Type Link Model (TLM)](https://type.link.model.tools/) Monorepo
+# Type Link Model (TLM) — retired
 
-TLM is a simple modelling technique inspired by [Object Role Modelling](https://en.wikipedia.org/wiki/Object-role_modeling) that is suitable for working with web APIs and the typical simple tree structures used in web documents.
+**TLM is archived and no longer maintained.** This repository is kept as a
+read-only record.
 
-This is an unfinished hobby project. _Use at your own risk._
+## What it was
 
-## Prerequisites
+TLM was a solo, unfinished experiment in *text-first fact-based modelling*: a
+way to describe a domain as a set of elementary facts written as plain
+sentences you can read aloud to a domain expert —
 
-- latest LTS [node](https://nodejs.org/)
-- recent [pnpm](https://pnpm.io/), if you have node, try `corepack enable`
-- [docker cli](https://github.com/docker/cli) installed and connected
+```
+A Person is identified by id which must be a URI.
+A Person has exactly one name.
+A Team has at least one lead which must be a Person.
+```
 
-## Build
+— and then generate the technical artifacts (schemas, diagrams, docs, SQL) from
+those facts. It drew on
+[Object-Role Modeling](https://en.wikipedia.org/wiki/Object-role_modeling)
+(ORM), simplified for web APIs and the simple tree structures common in web
+documents. It never got past the sketch stage.
 
-![CI](https://github.com/lsimons/tlm/workflows/CI/badge.svg)
+## Why it's retired
+
+This is a *contextual* decision, not doctrine. In 2026 the pragmatic landing
+spot for "models as code" is [LinkML](https://linkml.io/): it's maintained,
+peer-reviewed, and ships the whole generation pipeline — JSON Schema, ER/UML
+diagrams, docs, SQL DDL, Pydantic/TypeScript/Java — that TLM only sketched.
+Meanwhile the classical fact-based tooling TLM grew out of has withered to a
+couple of Windows-GUI survivors. So there was little reason to keep building TLM
+and good reason to point people at LinkML instead.
+
+LinkML is *not* a fact-based tool, and adopting it gives up two things TLM/ORM
+had: you stop reading the model as sentences, and example data moves out of the
+model into separate fixtures. Those losses — and why they're worth accepting
+today — are the subject of the article below.
+
+## Where it went
+
+- **Article:**
+  [Fact-based modelling and LinkML](https://leosimons.com/2026/07/26/fact-based-modelling-and-linkml/)
+  — the thinking behind this decision, with a LinkML worked example.
+- **Caseum**, the "M / Models" view — recommends LinkML for models-as-code.
+
+The durable idea here isn't "use LinkML." It's to **model just the facts, and
+find them by talking with domain experts — using examples, natural language, and
+simple drawings.** That's a human skill; it outlives any particular tool.
+
+## What's kept here
+
+As teaching artifacts, not as living code:
+
+- [`docs/spec/tlmd.md`](docs/spec/tlmd.md) — the TLMD notation, a clean
+  illustration of fact-oriented sentences.
+- [`docs/design/`](docs/design/) — sample models (HR, media, messages) in TLMD
+  and rendered into various formats.
+
+### TLMD → LinkML, roughly
+
+| TLMD sentence form  | LinkML                            |
+| ------------------- | --------------------------------- |
+| `is identified by`  | `identifier: true`                |
+| `has exactly one`   | `required: true` (single)         |
+| `has at most one`   | optional single (the default)     |
+| `has at least one`  | `required: true` + `multivalued: true` |
+| `can have some`     | `multivalued: true` (optional)    |
+| `has toggle`        | `range: boolean`                  |
+| `which must be a X` | `range: X`                        |
+
+LinkML labels only one direction of a link (so it loses TLM's coach/coachee
+named-role pairs) and has no XSD generator. See the article for the full worked
+example.
+
+## Building (for the record)
+
+The code still builds and its tests still pass. Requires
+[node](https://nodejs.org/), [pnpm](https://pnpm.io/) (`corepack enable`), and
+the [docker cli](https://github.com/docker/cli).
 
 ```shell
 mise install        # one-time: install pinned toolchains
 mise run install    # pnpm install
 mise run sql:setup  # start Postgres in Docker
-mise run test       # run all unit tests
+mise run test       # run the unit tests
 mise run sql:destroy
 ```
-
-## Code
-
-### TypeScript
-
-Code style follows [Biome](https://biomejs.dev/).
-
-### Commits
-
-Follow
-
-> https://conventionalcommits.org/
-
-with types:
-
-- build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-- ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-- docs: Documentation only changes
-- feat: A new feature
-- fix: A bug fix
-- perf: A code change that improves performance
-- refactor: A code change that neither fixes a bug nor adds a feature
-- revert: undoing (an)other commit(s)
-- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-- test: Adding missing tests or correcting existing tests
-- improvement: Improves code in some other way (that is not a feat or fix)
-- chore: Changes that take care of some other kind of chore that doesn't impact the main code
-
-(based on angular conventions https://github.com/angular/angular/blob/master/CONTRIBUTING.md#commit)
-
-### Dependency management
-
-- Run `pnpm update -r` to do minor dependency updates
-- Run `pnpm up -L -r` to do major dependency updates
-- Run `pnpm run x dedupe-deps` to add overrides to `package.json` to try and pin transitive dependencies to later versions
-
-## More info
-
-See [docs/](docs/).


### PR DESCRIPTION
Step 2 of the tlm archival (tidy → **tombstone** → archive). Rewrites
`README.md` as an honest tombstone now that the article is published.

## What the tombstone says
- **What TLM was** — a solo, unfinished text-first fact-based modelling
  experiment (with a sample fact-sentence block).
- **Why it's retired** — a *contextual* decision: LinkML is the maintained
  models-as-code landing spot; classical fact-based tooling has withered.
  Names the two honest losses (no sentence verbalization; example data moves
  to separate fixtures).
- **Where it went** — links the published article
  ([Fact-based modelling and LinkML](https://leosimons.com/2026/07/26/fact-based-modelling-and-linkml/))
  and Caseum's Models view; states the durable idea (model just the facts,
  found by talking with domain experts).
- **What's kept** — `docs/spec/tlmd.md` + `docs/design/` samples as teaching
  artifacts, plus a short TLMD → LinkML mapping table.
- A trimmed "Building (for the record)" section.

## Note
The prose leans on the wording from your archival plan and the published
article rather than composing fresh opinion — please adjust any phrasing to
taste before merge.

## Test plan
Docs-only change. CI runs the build + lint + test gate.

Co-Authored-By: lsimons-bot <bot@leosimons.com>